### PR TITLE
refactor: Удаление динамических импортов

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,17 @@ import base from "./configs/base"
 import ignore from "./configs/ignore"
 import createNuxtOptions from "./nuxtOptions"
 
+import accessibility from "./configs/accessibility"
+import depend from "./configs/depend"
+import jsdoc from "./configs/jsdoc"
+import jsonc from "./configs/jsonc"
+import sonar from "./configs/sonar"
+import tailwindcss from "./configs/tailwindcss"
+import unicorn from "./configs/unicorn"
+import vitest from "./configs/vitest"
+import vue from "./configs/vue"
+import yaml from "./configs/yaml"
+
 /**
  * Функция для создания конфигурации ESLint
  *
@@ -51,19 +62,20 @@ export default async function createESLintConfig(
 
   /** Список плагинов */
   const plugins = {
-    accessibility: "accessibility",
+    accessibility,
     deMorgan: [deMorgan.configs.recommended],
-    depend: "depend",
-    jsdoc: "jsdoc",
-    jsonc: "jsonc",
+    depend,
+    jsdoc,
+    jsonc,
     perfectionist: [perfectionist.configs["recommended-natural"]],
     prettier: [eslintConfigPrettier],
-    sonar: "sonar",
-    tailwindcss: "tailwindcss",
-    unicorn: "unicorn",
-    vitest: "vitest",
-    vue: "vue",
-    yaml: "yaml",
+    sonar,
+    tailwindcss,
+    unicorn,
+    // @ts-expect-error Несовпадение типов в библиотеке
+    vitest,
+    vue,
+    yaml,
   } as const satisfies Record<
     keyof typeof mergedOptions.plugins,
     Linter.Config<Linter.RulesRecord>[] | string
@@ -71,15 +83,10 @@ export default async function createESLintConfig(
 
   // Динамический импорт локальных плагинов
   for (const [plugin, config] of Object.entries(plugins)) {
+    // Если плагин включен в конфигурации
     if (mergedOptions.plugins[plugin as keyof typeof plugins]) {
-      if (typeof config === "string") {
-        // Если плагин является строкой, то он импортируется локально
-        const module = await import(`./configs/${config}.ts`)
-        eslintConfig.push(...module.default)
-      } else {
-        // Если плагин является массивом, то он импортируется из внешней зависимости
-        eslintConfig.push(...config)
-      }
+      // Добавляем конфигурацию плагина в конфигурацию ESLint
+      eslintConfig.push(...config)
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,10 @@ import perfectionist from "eslint-plugin-perfectionist"
 
 import type { ESLintConfigOptions } from "./types"
 
-import base from "./configs/base"
-import ignore from "./configs/ignore"
-import createNuxtOptions from "./nuxtOptions"
-
 import accessibility from "./configs/accessibility"
+import base from "./configs/base"
 import depend from "./configs/depend"
+import ignore from "./configs/ignore"
 import jsdoc from "./configs/jsdoc"
 import jsonc from "./configs/jsonc"
 import sonar from "./configs/sonar"
@@ -23,6 +21,7 @@ import unicorn from "./configs/unicorn"
 import vitest from "./configs/vitest"
 import vue from "./configs/vue"
 import yaml from "./configs/yaml"
+import createNuxtOptions from "./nuxtOptions"
 
 /**
  * Функция для создания конфигурации ESLint


### PR DESCRIPTION
Удалены динамические импорты конфигов в `index.ts` для правильной работы TSDown.